### PR TITLE
SF-551 Remove ForceCopy param as we are going to use CAssets

### DIFF
--- a/JsTrans.php
+++ b/JsTrans.php
@@ -59,7 +59,7 @@ class JsTrans
         // publish assets and generate dictionary file if neccessary
         if (!file_exists($this->_publishPath) || YII_DEBUG) {
             // publish and get new url and path
-            $this->_publishUrl  = $assetManager->publish($this->_assetsPath, false, -1, true);
+            $this->_publishUrl  = $assetManager->publish($this->_assetsPath, false, -1);
             $this->_publishPath = $assetManager->getPublishedPath($this->_assetsPath);
 
             // declare config (passed to JS)


### PR DESCRIPTION
Remove ForceCopy param as we are going to use CAssetsManager->linkAssets = true. SO will not have a problems with inconsistent assets and server will not spend time for files last modified time check
